### PR TITLE
fix: s3 presigned url 클릭 시 이미지 다운로드 아닌 브라우저에서 보이도록 수정

### DIFF
--- a/apps/authapp/views.py
+++ b/apps/authapp/views.py
@@ -173,7 +173,7 @@ class OurLoginView(LoginView):
     )
     def post(self, request, *args, **kwargs):
         self.request = request
-        
+
         # admin 계정이 아니고, 인증 메일 확인하기 전이면 403
         if (
             not self.request.user.is_superuser

--- a/apps/photoapp/utils.py
+++ b/apps/photoapp/utils.py
@@ -26,7 +26,7 @@ async def s3_upload_image(destination_blob_name, source_file_name):
         return False
 
 
-def generate_presigned_url(bucket, folder, key, expired_in, _method):
+def generate_presigned_url(bucket, folder, key, file_extension, expired_in, _method):
     try:
         s3 = boto3.client(
             "s3",
@@ -37,9 +37,23 @@ def generate_presigned_url(bucket, folder, key, expired_in, _method):
             ),
             region_name="ap-northeast-2",
         )
+        # 확장자에 따른 기본적인 Content-Type 매핑
+        mime_types = {
+            ".jpeg": "image/jpeg",
+            ".jpg": "image/jpeg",
+            ".png": "image/png",
+            ".gif": "image/gif",
+            ".bmp": "image/bmp",
+        }
+
+        # 확장자에 맞는 MIME 타입을 가져옴, 없을 경우 기본값
+        mime_type = mime_types.get(file_extension, "application/octet-stream")
+
         param = {
             "Bucket": bucket,
             "Key": f"{folder}/{key}",
+            "ResponseContentType": mime_type,  # 확장자에 따른 동적 MIME 타입 설정
+            "ResponseContentDisposition": "inline",  # 브라우저에서 바로 열리도록 설정
         }
         if _method == "put":
             param["ContentType"] = "image/*"

--- a/apps/photoapp/views.py
+++ b/apps/photoapp/views.py
@@ -1,3 +1,5 @@
+import os
+
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework import status
@@ -54,13 +56,20 @@ class ImageUploadAPIView(APIView):
         upload_tasks = []
         image_urls = []
         for x in images:
+            file_extension = os.path.splitext(x.name)[1]
+
             task = asyncio.create_task(s3_upload_image(f"{folder_dir}/{x}", x))
             x.file.seek(0)  # 파일 포인터를 처음으로 되돌림
             upload_tasks.append(task)
 
             # Presigned URL 생성
             presigned_url = generate_presigned_url(
-                self.S3_BUCKET_NAME, folder_dir, x, 60 * 60, "get"
+                self.S3_BUCKET_NAME,
+                folder_dir,
+                x,
+                file_extension,  # 파일 확장자명 전달
+                60 * 60,
+                "get",
             )
             image_urls.append(presigned_url)
 


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
기존 s3에 이미지 업로드 후 presigned url로 리턴받는 api에서 리턴 받은 url을 클릭하면 사진이 다운로드 되었는데, 저는 이 부분이 문제가 없다고 생각하였습니다.
그런데 조이님께서는 이 url을 그대로 spring에 넘겨 content나 thread를 생성하고 나중에 조회할 때 보여져야 한다고 일깨워주셔서
브라우저에 보이도록 수정했습니다.
**presigned url을 생성**하는 코드에서 `content type`을 설정하지 않았기에 다운로드가 되는 것이었고, 이를 추가하였습니다.

💁‍♀️ 참고 사항
auth쪽 로직은 수정하지 않았으나 formatter 설정으로 자동으로 엔터가 눌려진 것이 커밋된 것입니다.

🤔 논의 사항