### PR TITLE
Feat/confirm email template

### DIFF
--- a/apps/authapp/urls.py
+++ b/apps/authapp/urls.py
@@ -12,6 +12,7 @@ from .views import (
     PasswordResetRequestView,
     UserAuthenticationView,
     auth_redirect_view,
+    email_confirm,
 )
 
 urlpatterns = [
@@ -30,6 +31,7 @@ urlpatterns = [
         name="account_email_verification_sent",
     ),
     # 유저가 클릭한 이메일(=링크) 확인
+    path("email-confirm", email_confirm, name="email-confirm"),
     re_path(
         r"^account-confirm-email/(?P<key>[-:\w]+)/$",
         ConfirmEmailView.as_view(),

--- a/apps/authapp/views.py
+++ b/apps/authapp/views.py
@@ -341,7 +341,7 @@ class ConfirmEmailView(APIView):
         }
         response = requests.post(url, json=data)
 
-        return HttpResponseRedirect(redirect_to="http://localhost:3000/login")
+        return HttpResponseRedirect(redirect_to="/auth/email-confirm")
 
     def get_object(self, queryset=None):
         key = self.kwargs["key"]

--- a/apps/authapp/views.py
+++ b/apps/authapp/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import send_mail
 from django.http import HttpResponseRedirect, JsonResponse
+from django.shortcuts import render
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.utils.translation import gettext_lazy as _
@@ -173,7 +174,7 @@ class OurLoginView(LoginView):
     )
     def post(self, request, *args, **kwargs):
         self.request = request
-        
+
         # admin 계정이 아니고, 인증 메일 확인하기 전이면 403
         if (
             not self.request.user.is_superuser
@@ -308,6 +309,10 @@ class UserAuthenticationView(APIView):
             "authorization": authorization_status,
         }
         return JsonResponse(response_data)
+
+
+def email_confirm(request):
+    return render(request, "auth/email_confirm.html")
 
 
 @extend_schema(

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -5,7 +5,7 @@ from .base import *
 env = environ.Env(DEBUG=(bool, False))
 
 
-DEBUG = False
+DEBUG = True
 
 # 환경변수 파일 읽어오기
 environ.Env.read_env(env_file=os.path.join(BASE_DIR, ".env"))

--- a/templates/auth/email_confirm.html
+++ b/templates/auth/email_confirm.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증 완료</title>
+
+    <!-- Pretendard Font CDN -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css">
+
+    <style>
+        body {
+            font-family: 'Pretendard', sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            max-width: 600px;
+            width: 100%;
+            height: 100dvh;
+            margin: 0 auto;
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        .email-header {
+            text-align: center;
+            padding-bottom: 20px;
+        }
+        .email-header img {
+            width: 120px;
+        }
+        .email-content {
+            color: #333;
+            line-height: 1.6;
+        }
+        .email-footer {
+            text-align: center;
+            padding-top: 20px;
+            color: #999;
+            font-size: 12px;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            background-color: #11AFFF;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="email-header">
+            <h1>안녕하세요 회원님!</h1>
+        </div>
+        <div class="email-content">
+            <p>이메일 인증이 정상적으로 완료되었습니다.</p>
+            <p>이제 <strong>OurJourney</strong>로 돌아가셔서 로그인하신 후 모든 기능을 자유롭게 사용할 수 있습니다.</p>
+            <p>서비스를 이용해 주셔서 감사합니다!</p>
+            <div style="text-align: center; margin-top: 30px;">
+                <a href="https://our-journey-fe.vercel.app" class="button">OurJourney</a>
+            </div>
+        </div>
+        <div class="email-footer">
+            <p>본 메일은 발신 전용입니다. 궁금하신 점은 <a href="mailto:pudding4spoon@gmail.com">pudding4spoon@gmail.com</a>으로 문의해 주세요.</p>
+            <p>&copy; 2024 OurJourney. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
이메일 인증을 하라는 메일이 왔을 때, 인증 버튼을 클릭하면
다음과 같이 완료 화면으로 넘어가도록 django template을 추가하였습니다.
![image](https://github.com/user-attachments/assets/f5ea6ccb-7311-44b4-b5f7-99997b96abb4)

현재 글씨 폰트는 프론트에서 사용하는 것으로 하였고, 버튼 색상은 피그마 디자인 시스템에 있는 색상 중 하나를 임의로 설정하였습니다.

💁‍♀️ 참고 사항

🤔 논의 사항