### PR TITLE
fix: 이미지 업로드 로직 수정

### DIFF
--- a/apps/authapp/apps.py
+++ b/apps/authapp/apps.py
@@ -5,12 +5,14 @@ from django.db.models.signals import post_migrate
 
 def create_superuser(sender, **kwargs):
     User = get_user_model()
-    password = "adminpassword"
+    password = "tmvnsfoq123!"
 
     # 슈퍼유저가 존재하지 않는 경우에만 새 슈퍼유저 생성
     if not User.objects.filter(is_superuser=True).exists():
-        User.objects.create_superuser(email="admin@example.com", password=password)
-        print("Superuser created with email: admin@example.com")
+        User.objects.create_superuser(
+            email="pudding4spoon@gmail.com", password=password
+        )
+        print("Superuser created with email: pudding4spoon@gmail.com")
     else:
         print("Superuser already exists.")
 


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
django에서 이미지를 업로드 한 이후에 presigned url을 리턴하는데, 클라이언트는 이 url을 그대로 spring에게 보내서 db에는 presigned url이 저장되고 있었습니다.
그래서 만료 시간이 경과한 이미지는 화면상에서 확인할 수 없기에
presigned url이 아닌 s3 퍼블릭 이미지 url을 리턴하도록 로직을 수정하였습니다.


💁‍♀️ 참고 사항

🤔 논의 사항