### PR TITLE
fix: 이메일 인증 응답 예외처리 수정

### DIFF
--- a/apps/authapp/views.py
+++ b/apps/authapp/views.py
@@ -366,12 +366,9 @@ class ConfirmEmailView(APIView):
     def get(self, *args, **kwargs):
         confirmation = self.get_object()
 
-        # email_confirmation이 None이면 400 응답
+        # email_confirmation이 None => 이미 이메일 인증이 완료되었으나 별도의 400에러가 아닌 완료 템플릿으로 리다이렉트
         if confirmation is None:
-            return Response(
-                {"error": "Invalid or expired confirmation link."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            return HttpResponseRedirect(redirect_to="/auth/email-confirm")
 
         confirmation.confirm(self.request)
 


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
회원가입 후 메일함에서 이메일 인증 링크를 접속했을 때, 이미 인증된 경우 400 bad request로 화면에 표시되었는데,
이미 인증된 경우도 완료 템플릿으로 리다이렉트 되도록 수정하였습니다.

💁‍♀️ 참고 사항

🤔 논의 사항