### PR TITLE
feat: 사진 업로드 api에 이미지 확장자 유효성 검사 추가

### DIFF
--- a/apps/photoapp/utils.py
+++ b/apps/photoapp/utils.py
@@ -21,8 +21,6 @@ async def s3_upload_image(destination_blob_name, source_file_name, file_extensio
         if content_type is None:
             content_type = "application/octet-stream"  # 기본값 설정
 
-        print(content_type)
-
         await asyncio.to_thread(
             s3.Bucket(settings.S3_BUCKET_NAME).put_object,
             Key=destination_blob_name,

--- a/apps/photoapp/views.py
+++ b/apps/photoapp/views.py
@@ -53,10 +53,21 @@ class ImageUploadAPIView(APIView):
             )
 
     async def upload_images(self, bucket_name, folder_dir, images):
+        VALID_EXTENSIONS = [
+            ".jpg",
+            ".jpeg",
+            "png",
+            ".webp",
+            ".gif",
+        ]  # 유효한 파일 확장자 리스트
         upload_tasks = []
         image_urls = []
         for x in images:
             file_extension = os.path.splitext(x.name)[1]
+
+            # 파일 확장자 유효성 검사
+            if file_extension not in VALID_EXTENSIONS:
+                raise ValidationError({"error": _("허용되지 않는 파일 확장자입니다.")})
 
             # 파일을 다시 처음부터 읽을 수 있도록 설정
             x.file.seek(0)


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
프로필 이미지나 컨텐츠 이미지를 업로드할 때, `.jpg, .jpeg, .png, .webp, .gif` 외의 확장자를 가진 파일(ex: .hwp, .docx) 등은 업로드 되지 않도록, 확장자 validation을 추가했습니다.

💁‍♀️ 참고 사항

🤔 논의 사항