### PR TITLE
fix: png 파일 확장자 앞에 . 추가

### DIFF
--- a/apps/photoapp/views.py
+++ b/apps/photoapp/views.py
@@ -56,7 +56,7 @@ class ImageUploadAPIView(APIView):
         VALID_EXTENSIONS = [
             ".jpg",
             ".jpeg",
-            "png",
+            ".png",
             ".webp",
             ".gif",
         ]  # 유효한 파일 확장자 리스트


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
이미지 업로드 로직에서, 허용되는 파일 확장자를 설정했는데
png 파일에 대해 다음과 같이 `.`(dot)를 적지 않아서 오류가 발생했고 이를 수정하였습니다.

![image](https://github.com/user-attachments/assets/f9d8019a-a6ee-4dca-a4f3-b23b2c1665e3)

💁‍♀️ 참고 사항

🤔 논의 사항

