### PR TITLE
fix: 회원가입 시 중복 이메일 처리 로직 수정

### DIFF
--- a/apps/authapp/serializers.py
+++ b/apps/authapp/serializers.py
@@ -2,7 +2,7 @@ from allauth.account.adapter import get_adapter
 from allauth.account.utils import setup_user_email
 from dj_rest_auth.registration.serializers import RegisterSerializer
 from dj_rest_auth.serializers import LoginSerializer
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -18,6 +18,14 @@ class CustomRegisterSerializer(RegisterSerializer):
         # 폼에서 username 필드 제거
         if "username" in self.fields:
             self.fields.pop("username")
+
+    def validate_email(self, value):
+        User = get_user_model()
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError(
+                {"error": "이미 사용 중인 이메일입니다"}, code=400
+            )
+        return value
 
     def get_cleaned_data(self):
         return {


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
회원가입 시 중복된 이메일로 가입을 시도하는 경우, 응답 코드 400으로 리턴을 해야 되는데 
serializer 로직에서 validate_email 함수가 빠져 있었고 유효성 검사가 제대로 이루어지지 않아 500 에러가 발생했었습니다.
이를 수정했습니다.

💁‍♀️ 참고 사항

🤔 논의 사항