### PR TITLE
chore: signup api 응답에 \n 추가

### DIFF
--- a/apps/authapp/views.py
+++ b/apps/authapp/views.py
@@ -82,7 +82,7 @@ class CustomRegisterView(RegisterView):
                         name="Invalid Email Domain",
                         summary="이메일 도메인이 유효하지 않을 때",
                         value={
-                            "error": "유효하지 않은 이메일 도메인입니다. 이메일 주소를 확인하세요."
+                            "error": "유효하지 않은 이메일 도메인입니다.\n이메일 주소를 확인하세요."
                         },
                     ),
                     OpenApiExample(
@@ -114,7 +114,7 @@ class CustomRegisterView(RegisterView):
             return Response(
                 {
                     "error": _(
-                        "유효하지 않은 이메일 도메인입니다. 이메일 주소를 확인하세요."
+                        "유효하지 않은 이메일 도메인입니다.\n이메일 주소를 확인하세요."
                     )
                 },
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
🚨 관련 이슈

✨ 작업 내용
signup api에서 **유효하지 않은 이메일 도메인으로 가입할 때**의 에러 메시지가 길어서 프론트에서 토스트를 띄울 때 문제가 발생한다고 하여,
`\n`을 추가하였습니다.

💁‍♀️ 참고 사항

🤔 논의 사항